### PR TITLE
bug/fix TypeError ci 4.0.3

### DIFF
--- a/Datatables.php
+++ b/Datatables.php
@@ -107,9 +107,9 @@ class Datatables{
 	}
 
 	private function getOrdering(){
-		$orderField = esc($this->request->getPost('order')[0]['column']);
-		$orderAD = esc($this->request->getPost('order')[0]['dir']);
-		$orderColumn = esc($this->request->getPost('columns')[$orderField]['data']);
+		$orderField = esc($this->request->getPost('order')[0]['column']) ?? "";
+		$orderAD = esc($this->request->getPost('order')[0]['dir']) ?? "";
+		$orderColumn = esc($this->request->getPost('columns')[$orderField]['data']) ?? "";
 		$this->builder->orderBy($orderColumn, $orderAD);
 	}
 


### PR DESCRIPTION
TypeError
Argument 1 passed to CodeIgniter\Database\BaseBuilder::orderBy() must be of the type string, null given, called in ../app/Libraries/Datatables.php on line 128 

![image](https://user-images.githubusercontent.com/16358944/101583820-defce180-3a0e-11eb-8f80-84c82059f394.png)
